### PR TITLE
Add admin tools for managing players and teams

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ const HomePage = lazy(() => import('./pages/HomePage'));
 const LoginPage = lazy(() => import('./pages/LoginPage'));
 const RegisterPage = lazy(() => import('./pages/RegisterPage'));
 const TeamPage = lazy(() => import('./pages/TeamPage'));
+const AdminPage = lazy(() => import('./pages/AdminPage'));
 const NotFoundPage = lazy(() => import('./pages/NotFoundPage'));
 
 // Loading component for Suspense fallback
@@ -37,9 +38,10 @@ function App() {
                   <Routes>
                     <Route path="/" element={<HomePage />} />
                     <Route path="/login" element={<LoginPage />} />
-                    <Route path="/register" element={<RegisterPage />} />
-                    <Route path="/teams/:teamId" element={<TeamPage />} />
-                    <Route path="*" element={<NotFoundPage />} />
+                  <Route path="/register" element={<RegisterPage />} />
+                  <Route path="/teams/:teamId" element={<TeamPage />} />
+                  <Route path="/admin" element={<AdminPage />} />
+                  <Route path="*" element={<NotFoundPage />} />
                   </Routes>
                 </Suspense>
               </Layout>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -9,6 +9,7 @@ type LayoutProps = {
 export default function Layout({ children }: LayoutProps) {
   const { user, signOut } = useAuth();
   const location = useLocation();
+  const isAdmin = user?.email?.endsWith('@admin.com') ?? false;
 
   return (
     <div className="min-h-screen flex flex-col">
@@ -30,15 +31,27 @@ export default function Layout({ children }: LayoutProps) {
               Draft Board
             </Link>
             {user && (
-              <Link 
+              <Link
                 to={`/teams/${user.id}`}
                 className={`px-3 py-2 rounded-md text-sm font-medium ${
-                  location.pathname.startsWith('/teams/') 
-                    ? 'bg-indigo-100 text-indigo-700' 
+                  location.pathname.startsWith('/teams/')
+                    ? 'bg-indigo-100 text-indigo-700'
                     : 'text-gray-700 hover:bg-gray-100'
                 }`}
               >
                 My Team
+              </Link>
+            )}
+            {isAdmin && (
+              <Link
+                to="/admin"
+                className={`px-3 py-2 rounded-md text-sm font-medium ${
+                  location.pathname === '/admin'
+                    ? 'bg-indigo-100 text-indigo-700'
+                    : 'text-gray-700 hover:bg-gray-100'
+                }`}
+              >
+                Admin
               </Link>
             )}
           </nav>

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+import { toast } from 'react-hot-toast';
+import { playersApi, teamsApi, type PlayerPosition } from '../services/supabase';
+import { useApp } from '../context/AppContext';
+
+const positionOptions: PlayerPosition[] = [
+  'Point Guard',
+  'Shooting Guard',
+  'Lock',
+  'Power Forward',
+  'Center',
+];
+
+const AdminPage = () => {
+  const { currentEventId } = useApp();
+  const [playerName, setPlayerName] = useState('');
+  const [playerPosition, setPlayerPosition] = useState<PlayerPosition | ''>('');
+  const [teamName, setTeamName] = useState('');
+  const [teamLogoUrl, setTeamLogoUrl] = useState('');
+
+  const handleAddPlayer = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!currentEventId) return toast.error('No event selected');
+    try {
+      await playersApi.create(playerName, playerPosition || null, currentEventId);
+      toast.success('Player added');
+      setPlayerName('');
+      setPlayerPosition('');
+    } catch (err) {
+      toast.error((err as Error).message);
+    }
+  };
+
+  const handleAddTeam = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!currentEventId) return toast.error('No event selected');
+    try {
+      await teamsApi.create(teamName, currentEventId, teamLogoUrl || null);
+      toast.success('Team added');
+      setTeamName('');
+      setTeamLogoUrl('');
+    } catch (err) {
+      toast.error((err as Error).message);
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      <div className="bg-white shadow rounded-lg p-6">
+        <h2 className="text-xl font-bold mb-4">Add Player</h2>
+        <form onSubmit={handleAddPlayer} className="space-y-4">
+          <input
+            type="text"
+            placeholder="Player Name"
+            value={playerName}
+            onChange={(e) => setPlayerName(e.target.value)}
+            className="w-full border rounded px-3 py-2"
+          />
+          <select
+            value={playerPosition}
+            onChange={(e) => setPlayerPosition(e.target.value as PlayerPosition)}
+            className="w-full border rounded px-3 py-2"
+          >
+            <option value="">Select position</option>
+            {positionOptions.map((pos) => (
+              <option key={pos} value={pos}>
+                {pos}
+              </option>
+            ))}
+          </select>
+          <button type="submit" className="px-4 py-2 bg-indigo-600 text-white rounded">
+            Add Player
+          </button>
+        </form>
+      </div>
+
+      <div className="bg-white shadow rounded-lg p-6">
+        <h2 className="text-xl font-bold mb-4">Add Team</h2>
+        <form onSubmit={handleAddTeam} className="space-y-4">
+          <input
+            type="text"
+            placeholder="Team Name"
+            value={teamName}
+            onChange={(e) => setTeamName(e.target.value)}
+            className="w-full border rounded px-3 py-2"
+          />
+          <input
+            type="text"
+            placeholder="Logo URL (optional)"
+            value={teamLogoUrl}
+            onChange={(e) => setTeamLogoUrl(e.target.value)}
+            className="w-full border rounded px-3 py-2"
+          />
+          <button type="submit" className="px-4 py-2 bg-indigo-600 text-white rounded">
+            Add Team
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default AdminPage;

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -233,6 +233,27 @@ export const teamsApi = {
     if (error) return null;
     return data;
   },
+
+  create: async (name: string, eventId: string, logoUrl?: string | null): Promise<Team | null> => {
+    const isAuthenticated = await ensureAuth();
+    if (!isAuthenticated) {
+      throw new Error('You must be authenticated to create a team');
+    }
+
+    const slug = name.toLowerCase().replace(/\s+/g, '-');
+
+    const { data, error } = await supabase
+      .from('teams')
+      .insert({ name, slug, logo_url: logoUrl || null, event_id: eventId })
+      .select('*')
+      .single();
+
+    if (error) {
+      handleApiError(error, 'creating team');
+      return null;
+    }
+    return data as Team;
+  },
 };
 
 // Players API
@@ -288,6 +309,30 @@ export const playersApi = {
       ...player,
       updated_at: player.updated_at
     }));
+  },
+
+  create: async (
+    name: string,
+    position: PlayerPosition | null,
+    eventId: string
+  ): Promise<Player | null> => {
+    const isAuthenticated = await ensureAuth();
+    if (!isAuthenticated) {
+      throw new Error('You must be authenticated to create a player');
+    }
+
+    const { data, error } = await supabase
+      .from('players')
+      .insert({ name, position, event_id: eventId })
+      .select('*')
+      .single();
+
+    if (error) {
+      handleApiError(error, 'creating player');
+      return null;
+    }
+
+    return { ...data, updated_at: data.updated_at } as Player;
   },
 
   draftPlayer: async (playerId: string, teamId: string, pickNumber: number): Promise<void> => {


### PR DESCRIPTION
## Summary
- add AdminPage with forms to create players and teams
- expose new `create` methods on `teamsApi` and `playersApi`
- link AdminPage via route and navigation for admin users

## Testing
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_687433da880c8328a39658658d7737ac