### PR TITLE
Add fade-in animations to core sections

### DIFF
--- a/src/components/DraftBoard.tsx
+++ b/src/components/DraftBoard.tsx
@@ -27,7 +27,7 @@ const DraftBoard = ({
   const remainingPicks = teams.length * 16 - totalPicks;
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-8 animate-fade-in">
       <DraftHeader
         currentTeam={currentTeam}
         currentPick={currentPick}

--- a/src/components/TeamCard.tsx
+++ b/src/components/TeamCard.tsx
@@ -107,10 +107,10 @@ const TeamCard: React.FC<TeamCardProps> = ({
   }, [positionCounts]);
 
   return (
-    <article 
+    <article
       className={`bg-white rounded-lg shadow overflow-hidden w-full ${
         isCurrentTeam ? 'ring-2 ring-indigo-500' : ''
-      }`}
+      } animate-fade-in`}
       aria-labelledby={`team-${team.id}-name`}
       aria-describedby={`team-${team.id}-picks`}
     >

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -130,7 +130,7 @@ const AdminPage = () => {
   };
 
   return (
-    <div className="space-y-8 p-4">
+    <div className="space-y-8 p-4 animate-fade-in">
       <div className="bg-white shadow rounded-lg p-6">
         <h2 className="text-2xl font-bold mb-6 text-gray-800">Create Event</h2>
         <form onSubmit={handleCreateEvent} className="space-y-4">

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -73,7 +73,7 @@ const HomePage = () => {
   }
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-8 animate-fade-in">
       <DraftBoard 
         currentTeam={currentTeam}
         currentPick={currentPick}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -45,7 +45,7 @@ const LoginPage = () => {
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-md w-full space-y-8">
+      <div className="max-w-md w-full space-y-8 animate-fade-in">
         <div>
           <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
             Sign in to your account

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 const NotFoundPage = () => {
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4 py-12 sm:px-6 lg:px-8">
-      <div className="max-w-md w-full space-y-8 text-center">
+      <div className="max-w-md w-full space-y-8 text-center animate-fade-in">
         <div>
           <h1 className="text-9xl font-bold text-indigo-600">404</h1>
           <h2 className="mt-6 text-3xl font-extrabold text-gray-900">

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -84,7 +84,7 @@ export default function RegisterPage() {
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-md w-full space-y-8">
+      <div className="max-w-md w-full space-y-8 animate-fade-in">
         <div>
           <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
             Create your account

--- a/src/pages/TeamPage.tsx
+++ b/src/pages/TeamPage.tsx
@@ -31,7 +31,7 @@ const TeamPage = () => {
   }
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-8 animate-fade-in">
       {/* Team Header */}
       <div className="bg-white shadow rounded-lg overflow-hidden">
         <div className="px-6 py-8 sm:px-8">


### PR DESCRIPTION
## Summary
- apply `animate-fade-in` to DraftBoard
- apply fade-in effect to TeamCard component
- make primary page sections fade in on load

## Testing
- `npm run lint` *(fails: Unexpected any in multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_68746ac2572c83289489254e26b82779