### PR TITLE
Improve table and card styling

### DIFF
--- a/src/components/DraftPicksTable.tsx
+++ b/src/components/DraftPicksTable.tsx
@@ -11,7 +11,7 @@ type DraftPicksTableComponent = (props: DraftPicksTableProps) => React.JSX.Eleme
 const DraftPicksTable: DraftPicksTableComponent = ({ draftPicks, teams }) => {
   const renderDraftPicks = () => {
     return draftPicks.slice().reverse().map((pick: DraftPick) => (
-      <tr key={pick.id} className="hover:bg-gray-50">
+      <tr key={pick.id} className="odd:bg-blue-50 hover:bg-blue-100">
         <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
           {pick.pick}
         </td>
@@ -30,12 +30,12 @@ const DraftPicksTable: DraftPicksTableComponent = ({ draftPicks, teams }) => {
 
   return (
     <div className="bg-white shadow rounded-lg overflow-hidden">
-      <div className="px-6 py-4 border-b border-gray-200">
+      <div className="px-6 py-4 border-b border-blue-200 bg-blue-50">
         <h3 className="text-lg font-medium text-gray-900">Recent Picks</h3>
       </div>
       <div className="overflow-x-auto">
         <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
+          <thead className="bg-blue-50">
             <tr>
               <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                 Pick

--- a/src/components/PlayerList.tsx
+++ b/src/components/PlayerList.tsx
@@ -126,7 +126,7 @@ const PlayerList = (props: PlayerListProps) => {
     >
       <div className="inline-block min-w-full align-middle">
         <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
+          <thead className="bg-blue-50">
             <tr>
             <th 
               scope="col" 

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -85,7 +85,7 @@ const HomePage = () => {
       />
       
       <div className="bg-white shadow rounded-lg overflow-hidden">
-        <div className="px-6 py-4 border-b border-gray-200">
+        <div className="px-6 py-4 border-b border-blue-200 bg-blue-50">
           <h2 className="text-lg font-medium text-gray-900">
             Available Players <span className="text-gray-500">({players.length})</span>
           </h2>

--- a/src/pages/TeamPage.tsx
+++ b/src/pages/TeamPage.tsx
@@ -68,7 +68,7 @@ const TeamPage = () => {
 
       {/* Team Picks */}
       <div className="bg-white shadow rounded-lg overflow-hidden">
-        <div className="px-6 py-4 border-b border-gray-200">
+        <div className="px-6 py-4 border-b border-blue-200 bg-blue-50">
           <h2 className="text-lg font-medium text-gray-900 mb-4">Draft Picks</h2>
         </div>
         {teamPicks.length === 0 ? (
@@ -78,7 +78,7 @@ const TeamPage = () => {
         ) : (
           <div className="overflow-x-auto">
             <table className="min-w-full divide-y divide-gray-200">
-              <thead className="bg-gray-50">
+              <thead className="bg-blue-50">
                 <tr>
                   <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                     Pick
@@ -119,7 +119,7 @@ const TeamPage = () => {
 
       {/* Team Needs Analysis */}
       <div className="bg-white shadow rounded-lg overflow-hidden">
-        <div className="px-6 py-4 border-b border-gray-200">
+        <div className="px-6 py-4 border-b border-blue-200 bg-blue-50">
           <h3 className="text-lg font-medium text-gray-900">Team Stats</h3>
         </div>
         <div className="p-6">


### PR DESCRIPTION
## Summary
- add blue background to table headers and card headers
- highlight odd and hover states for draft picks rows

## Testing
- `npm run lint` *(fails: Unexpected any in various files)*

------
https://chatgpt.com/codex/tasks/task_e_68746c772cac832892e7f1f4912685de