### PR TITLE
Adjust heading sizes and emphasize key titles

### DIFF
--- a/src/components/DraftHeader.tsx
+++ b/src/components/DraftHeader.tsx
@@ -32,7 +32,7 @@ export const DraftHeader: DraftHeaderComponent = ({
     <div className="bg-white shadow rounded-lg p-6">
       <div className="flex flex-col md:flex-row md:items-center md:justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Draft Board</h1>
+          <h1 className="uppercase tracking-wide text-brand-blue-700 dark:text-brand-blue-200">Draft Board</h1>
           <p className="mt-1 text-sm text-gray-500">
             {totalPicks} picks made • {remainingPicks} players remaining
           </p>

--- a/src/index.css
+++ b/src/index.css
@@ -17,12 +17,12 @@
     @apply font-bold text-brand-blue-900 dark:text-brand-blue-200 leading-tight tracking-tight;
   }
   
-  h1 { @apply text-4xl; }
-  h2 { @apply text-3xl; }
-  h3 { @apply text-2xl; }
-  h4 { @apply text-xl; }
-  h5 { @apply text-lg; }
-  h6 { @apply text-base; }
+  h1 { @apply text-5xl; }
+  h2 { @apply text-4xl; }
+  h3 { @apply text-3xl; }
+  h4 { @apply text-2xl; }
+  h5 { @apply text-xl; }
+  h6 { @apply text-lg; }
   
   p {
     @apply text-gray-600 dark:text-gray-300 leading-relaxed;


### PR DESCRIPTION
## Summary
- enlarge default heading sizes in `index.css`
- style the "Draft Board" title with uppercase, tracking, and brand color

## Testing
- `npm run lint` *(fails: unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68746c7b47348328b5824f0f145abbe5