### PR TITLE
Add hover effects and button scaling

### DIFF
--- a/src/components/DraftHeader.tsx
+++ b/src/components/DraftHeader.tsx
@@ -29,7 +29,7 @@ export const DraftHeader: DraftHeaderComponent = ({
   onResetDraft,
 }) => {
   return (
-    <div className="bg-white shadow rounded-lg p-6">
+    <div className="bg-white shadow rounded-lg p-6 hover:shadow-lg transition-shadow">
       <div className="flex flex-col md:flex-row md:items-center md:justify-between">
         <div>
           <h1 className="text-2xl font-bold text-gray-900">Draft Board</h1>

--- a/src/components/DraftPicksTable.tsx
+++ b/src/components/DraftPicksTable.tsx
@@ -11,7 +11,7 @@ type DraftPicksTableComponent = (props: DraftPicksTableProps) => React.JSX.Eleme
 const DraftPicksTable: DraftPicksTableComponent = ({ draftPicks, teams }) => {
   const renderDraftPicks = () => {
     return draftPicks.slice().reverse().map((pick: DraftPick) => (
-      <tr key={pick.id} className="hover:bg-gray-50">
+      <tr key={pick.id} className="hover:bg-gray-50 hover:shadow transition-shadow">
         <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
           {pick.pick}
         </td>
@@ -29,7 +29,7 @@ const DraftPicksTable: DraftPicksTableComponent = ({ draftPicks, teams }) => {
   };
 
   return (
-    <div className="bg-white shadow rounded-lg overflow-hidden">
+    <div className="bg-white shadow rounded-lg overflow-hidden hover:shadow-lg transition-shadow">
       <div className="px-6 py-4 border-b border-gray-200">
         <h3 className="text-lg font-medium text-gray-900">Recent Picks</h3>
       </div>

--- a/src/components/PlayerList.tsx
+++ b/src/components/PlayerList.tsx
@@ -163,9 +163,9 @@ const PlayerList = (props: PlayerListProps) => {
         </thead>
         <tbody className="bg-white divide-y divide-gray-200">
           {sortedPlayers(players).map((player) => (
-            <tr 
-              key={player.id} 
-              className="hover:bg-gray-50 cursor-pointer"
+            <tr
+              key={player.id}
+              className="hover:bg-gray-50 hover:shadow cursor-pointer transition-shadow"
               onClick={() => onSelectPlayer?.(player)}
               onKeyDown={(e) => {
                 if ((e.key === 'Enter' || e.key === ' ') && onSelectPlayer) {

--- a/src/components/TeamCard.tsx
+++ b/src/components/TeamCard.tsx
@@ -107,8 +107,8 @@ const TeamCard: React.FC<TeamCardProps> = ({
   }, [positionCounts]);
 
   return (
-    <article 
-      className={`bg-white rounded-lg shadow overflow-hidden w-full ${
+    <article
+      className={`bg-white rounded-lg shadow overflow-hidden w-full hover:shadow-lg transition-shadow ${
         isCurrentTeam ? 'ring-2 ring-brand-blue-500' : ''
       }`}
       aria-labelledby={`team-${team.id}-name`}

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -131,7 +131,7 @@ const AdminPage = () => {
 
   return (
     <div className="space-y-8 p-4">
-      <div className="bg-white shadow rounded-lg p-6">
+      <div className="bg-white shadow rounded-lg p-6 hover:shadow-lg transition-shadow">
         <h2 className="text-2xl font-bold mb-6 text-gray-800">Create Event</h2>
         <form onSubmit={handleCreateEvent} className="space-y-4">
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
@@ -265,7 +265,7 @@ const AdminPage = () => {
         </form>
       </div>
 
-      <div className="bg-white shadow rounded-lg p-6">
+      <div className="bg-white shadow rounded-lg p-6 hover:shadow-lg transition-shadow">
         <h2 className="text-2xl font-bold mb-6 text-gray-800">Add Player</h2>
         <form onSubmit={handleAddPlayer} className="space-y-4">
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
@@ -316,7 +316,7 @@ const AdminPage = () => {
         </form>
       </div>
 
-      <div className="bg-white shadow rounded-lg p-6">
+      <div className="bg-white shadow rounded-lg p-6 hover:shadow-lg transition-shadow">
         <h2 className="text-2xl font-bold mb-6 text-gray-800">Add Team</h2>
         <form onSubmit={handleAddTeam} className="space-y-4">
           <div>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -84,7 +84,7 @@ const HomePage = () => {
         isAdmin={isAdmin}
       />
       
-      <div className="bg-white shadow rounded-lg overflow-hidden">
+      <div className="bg-white shadow rounded-lg overflow-hidden hover:shadow-lg transition-shadow">
         <div className="px-6 py-4 border-b border-gray-200">
           <h2 className="text-lg font-medium text-gray-900">
             Available Players <span className="text-gray-500">({players.length})</span>
@@ -149,7 +149,7 @@ const PlayerItem = ({ player, onSelect, disabled }: PlayerItemProps) => (
       <button
         onClick={() => onSelect(player)}
         disabled={disabled}
-        className={`inline-flex items-center px-3 py-1.5 border text-xs font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 ${
+        className={`inline-flex items-center px-3 py-1.5 border text-xs font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 transition-transform hover:scale-105 active:scale-95 ${
           disabled
             ? 'bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed'
             : 'bg-brand-blue-600 text-white border-transparent hover:bg-brand-blue-700 focus:ring-brand-blue-500'

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -121,7 +121,7 @@ const LoginPage = () => {
             <button
               type="submit"
               disabled={isLoading}
-              className={`group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-brand-blue-600 hover:bg-brand-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-blue-500 ${
+              className={`group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-brand-blue-600 hover:bg-brand-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-blue-500 transition-transform hover:scale-105 active:scale-95 ${
                 isLoading ? 'opacity-70 cursor-not-allowed' : ''
               }`}
             >

--- a/src/pages/TeamPage.tsx
+++ b/src/pages/TeamPage.tsx
@@ -33,7 +33,7 @@ const TeamPage = () => {
   return (
     <div className="space-y-8">
       {/* Team Header */}
-      <div className="bg-white shadow rounded-lg overflow-hidden">
+      <div className="bg-white shadow rounded-lg overflow-hidden hover:shadow-lg transition-shadow">
         <div className="px-6 py-8 sm:px-8">
           <div className="flex items-center space-x-6">
             <div className="flex-shrink-0">
@@ -67,7 +67,7 @@ const TeamPage = () => {
       </div>
 
       {/* Team Picks */}
-      <div className="bg-white shadow rounded-lg overflow-hidden">
+      <div className="bg-white shadow rounded-lg overflow-hidden hover:shadow-lg transition-shadow">
         <div className="px-6 py-4 border-b border-gray-200">
           <h2 className="text-lg font-medium text-gray-900 mb-4">Draft Picks</h2>
         </div>
@@ -96,7 +96,7 @@ const TeamPage = () => {
               </thead>
               <tbody className="bg-white divide-y divide-gray-200">
                 {teamPicks.map((pick: DraftPick) => (
-                    <tr key={pick.id} className="hover:bg-gray-50">
+                    <tr key={pick.id} className="hover:bg-gray-50 hover:shadow transition-shadow">
                       <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
                         {pick.pick}
                       </td>
@@ -118,7 +118,7 @@ const TeamPage = () => {
       </div>
 
       {/* Team Needs Analysis */}
-      <div className="bg-white shadow rounded-lg overflow-hidden">
+      <div className="bg-white shadow rounded-lg overflow-hidden hover:shadow-lg transition-shadow">
         <div className="px-6 py-4 border-b border-gray-200">
           <h3 className="text-lg font-medium text-gray-900">Team Stats</h3>
         </div>


### PR DESCRIPTION
## Summary
- animate drafting buttons and login button with subtle scale effects
- emphasize cards with hover shadows
- add hover shadows to table rows for better feedback

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68746c87a33883288616cfff4a727a61