### PR TITLE
Add draft admin page with tabbed dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ const RegisterPage = lazy(() => import('./pages/RegisterPage'));
 const TeamPage = lazy(() => import('./pages/TeamPage'));
 const TeamsPage = lazy(() => import('./pages/TeamsPage'));
 const AdminPage = lazy(() => import('./pages/AdminPage'));
+const AdminDashboardPage = lazy(() => import('./pages/AdminDashboardPage'));
 const PlayersPage = lazy(() => import('./pages/PlayersPage'));
 const DraftBoardPage = lazy(() => import('./pages/DraftBoardPage'));
 const NotFoundPage = lazy(() => import('./pages/NotFoundPage'));
@@ -44,7 +45,7 @@ function App() {
                     <Route path="/register" element={<RegisterPage />} />
                     <Route path="/teams" element={<TeamsPage />} />
                     <Route path="/teams/:teamId" element={<TeamPage />} />
-                    <Route path="/admin" element={<AdminPage />} />
+                    <Route path="/admin" element={<AdminDashboardPage />} />
                     <Route path="/players" element={<PlayersPage />} />
                     <Route path="/draft" element={<DraftBoardPage />} />
                     <Route path="*" element={<NotFoundPage />} />

--- a/src/pages/AdminDashboardPage.tsx
+++ b/src/pages/AdminDashboardPage.tsx
@@ -1,0 +1,21 @@
+import { lazy, Suspense } from 'react';
+import Tabs from '../components/ui/Tabs';
+import LoadingSpinner from '../components/LoadingSpinner';
+
+const PlayerTeamAdmin = lazy(() => import('./AdminPage'));
+const DraftAdmin = lazy(() => import('./DraftAdminPage'));
+
+const AdminDashboardPage = () => {
+  const tabs = [
+    { id: 'draft', label: 'Draft Admin', content: <DraftAdmin /> },
+    { id: 'manage', label: 'Player & Team Admin', content: <PlayerTeamAdmin /> },
+  ];
+
+  return (
+    <Suspense fallback={<LoadingSpinner className="mt-6" size="lg" />}>
+      <Tabs tabs={tabs} />
+    </Suspense>
+  );
+};
+
+export default AdminDashboardPage;

--- a/src/pages/DraftAdminPage.tsx
+++ b/src/pages/DraftAdminPage.tsx
@@ -1,0 +1,133 @@
+import React, { useMemo } from 'react';
+import { useDraft } from '../context/DraftContext/useDraft';
+import { useApp } from '../context/AppContext';
+import { useQuery } from '@tanstack/react-query';
+import { eventsApi } from '../services/events';
+import DraftPicksTable from '../components/DraftPicksTable';
+
+const DraftAdminPage = () => {
+  const { currentEventId } = useApp();
+  const {
+    teams,
+    draftPicks,
+    currentPick,
+    isPaused,
+    togglePause,
+    resetDraft,
+  } = useDraft();
+
+  const { data: currentEvent } = useQuery({
+    queryKey: ['currentEvent', currentEventId],
+    queryFn: () => (currentEventId ? eventsApi.getById(currentEventId) : null),
+    enabled: !!currentEventId,
+  });
+
+  const picksPerTeam = currentEvent?.picksPerTeam || 15;
+  const totalPicks = teams.length * picksPerTeam;
+
+  const upcomingPicks = useMemo(() => {
+    if (!teams.length) return [] as Array<{ pick: number; round: number; teamName: string; teamLogo?: string | null }>;
+    const sortedTeams = [...teams].sort((a, b) => (a.draft_order || 0) - (b.draft_order || 0));
+    const result: Array<{ pick: number; round: number; teamName: string; teamLogo?: string | null }> = [];
+    let next = currentPick + 1;
+    while (next <= totalPicks && result.length < 20) {
+      const round = Math.ceil(next / sortedTeams.length);
+      const pickInRound = ((next - 1) % sortedTeams.length) + 1;
+      const index = round % 2 === 1 ? pickInRound - 1 : sortedTeams.length - pickInRound;
+      const team = sortedTeams[index];
+      result.push({ pick: next, round, teamName: team.name, teamLogo: team.logo_url });
+      next += 1;
+    }
+    return result;
+  }, [teams, currentPick, totalPicks]);
+
+  const pastPicks = useMemo(() => {
+    return draftPicks
+      .slice()
+      .sort((a, b) => (b.pick_number || b.pick) - (a.pick_number || a.pick));
+  }, [draftPicks]);
+
+  const handleStart = async () => {
+    if (isPaused && currentPick === 1) {
+      togglePause();
+    } else if (isPaused) {
+      togglePause();
+    } else {
+      await resetDraft();
+      togglePause();
+    }
+  };
+
+  const handleEnd = async () => {
+    await resetDraft();
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex space-x-2">
+        <button
+          onClick={handleStart}
+          className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
+        >
+          {isPaused && currentPick === 1 ? 'Start Draft' : isPaused ? 'Resume' : 'Restart'}
+        </button>
+        <button
+          onClick={togglePause}
+          className="px-4 py-2 bg-yellow-500 text-white rounded hover:bg-yellow-600"
+        >
+          {isPaused ? 'Resume' : 'Pause'}
+        </button>
+        <button
+          onClick={handleEnd}
+          className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
+        >
+          End Draft
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div className="bg-white shadow rounded-lg p-4">
+          <h2 className="text-lg font-semibold mb-2">Upcoming Draft Order</h2>
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Pick</th>
+                  <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Team</th>
+                  <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Round</th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                {upcomingPicks.length === 0 ? (
+                  <tr>
+                    <td colSpan={3} className="px-4 py-4 text-center text-sm text-gray-500">No upcoming picks</td>
+                  </tr>
+                ) : (
+                  upcomingPicks.map((pick) => (
+                    <tr key={pick.pick}>
+                      <td className="px-4 py-2 whitespace-nowrap">#{pick.pick}</td>
+                      <td className="px-4 py-2 whitespace-nowrap flex items-center space-x-2">
+                        {pick.teamLogo ? (
+                          <img src={pick.teamLogo} alt="" className="h-5 w-5 rounded-full" />
+                        ) : null}
+                        <span>{pick.teamName}</span>
+                      </td>
+                      <td className="px-4 py-2 whitespace-nowrap">{pick.round}</td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div className="bg-white shadow rounded-lg p-4">
+          <h2 className="text-lg font-semibold mb-2">Past Picks</h2>
+          <DraftPicksTable draftPicks={pastPicks} teams={teams} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DraftAdminPage;


### PR DESCRIPTION
## Summary
- add DraftAdminPage with start, pause and end controls
- show upcoming draft order and past picks tables
- create AdminDashboardPage with tabs to switch between draft admin and existing admin page
- route `/admin` to the new dashboard

## Testing
- `npm test` *(fails: Playwright test complains about describe usage)*

------
https://chatgpt.com/codex/tasks/task_e_6876017d6c94832893a1ccc26397adb3