### PR TITLE
Fix available players list

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -18,16 +18,16 @@ const positionOrder: Record<string, number> = {
 
 const HomePage = () => {
   const { user } = useAuth();
-  const { 
-    teams, 
-    currentPick, 
-    isLoading, 
-    togglePause, 
-    resetDraft, 
-    isPaused, 
-    timeLeft, 
-    selectPlayer, 
-    players: availablePlayers,
+  const {
+    teams,
+    currentPick,
+    isLoading,
+    togglePause,
+    resetDraft,
+    isPaused,
+    timeLeft,
+    selectPlayer,
+    availablePlayers,
     playersQuery
   } = useDraft();
 


### PR DESCRIPTION
## Summary
- fix available players list not loading by using `availablePlayers` from the draft context

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_687607f4570483289c4fe1a1a7ce5047